### PR TITLE
Insert defaults

### DIFF
--- a/defaults.go
+++ b/defaults.go
@@ -9,6 +9,12 @@ import (
 //		   robert@synthesis.ai
 //         github.com/rkotcher-synthesisai
 
+// NOTE special thanks to GH user juju for the inspiration behind this functionality
+// I studied their fork of this repo when I was working on this. Some notable differences
+// are: 1) InsertDefaults does not accept nil now, 2) I added support for default
+// values w/in arrays. You can check out the work juju did on their fork at:
+// https://godoc.org/github.com/juju/gojsonschema
+
 // InsertDefaults takes a generic interface (because it could either be an
 // object or an array, and attemps to fill it with as many defaults as possible
 func (s *Schema) InsertDefaults(into interface{}) (m interface{}, returnErr error) {

--- a/defaults.go
+++ b/defaults.go
@@ -59,10 +59,6 @@ func insertRecursively(into interface{}, from map[string]interface{}) {
 		}
 
 	case "object":
-		if into == nil {
-			into = make(map[string]interface{})
-		}
-
 		intoAsObject := into.(map[string]interface{})
 
 		// nextMap represents the subSchema that we want this single item to

--- a/defaults.go
+++ b/defaults.go
@@ -1,0 +1,123 @@
+package gojsonschema
+
+import (
+	"errors"
+	"fmt"
+)
+
+// Author: Robert Kotcher
+//		   robert@synthesis.ai
+//         github.com/rkotcher-synthesisai
+
+// InsertDefaults takes a generic interface (because it could either be an
+// object or an array, and attemps to fill it with as many defaults as possible
+func (s *Schema) InsertDefaults(into interface{}) (m interface{}, returnErr error) {
+	defer panicHandler(&returnErr)
+
+	// We need to get the outermost document before entering the recursive function
+	// because we'll recurse down into this map as well.
+	schemaMap := s.getDocumentMap()
+
+	insertRecursively(into, schemaMap)
+
+	return into, nil // err is filled if panic
+}
+
+func panicHandler(err *error) {
+	if r := recover(); r != nil {
+		var msg string
+		switch t := r.(type) {
+		case error:
+			msg = fmt.Sprintf("schema error caused a panic: %s", t.Error())
+		default:
+			msg = fmt.Sprintf("unknown panic: %#v", t)
+		}
+		*err = errors.New(msg)
+	}
+}
+
+func (s *Schema) getDocumentMap() map[string]interface{} {
+	f, _ := s.pool.GetDocument(s.documentReference)
+	return f.Document.(map[string]interface{})
+}
+
+// insertRecursively inserts into "into", which is either an array or an object
+func insertRecursively(into interface{}, from map[string]interface{}) {
+
+	switch t := from["type"]; t {
+
+	case "array":
+		// intoAsArray represents many objects of the same type
+		intoAsArray := into.([]map[string]interface{})
+
+		// nextMap represents the subSchema that we want each item in the array
+		// to conform to
+		nextMap := from["items"].(map[string]interface{})
+
+		for _, example := range intoAsArray {
+			insertRecursively(example, nextMap)
+		}
+
+	case "object":
+		if into == nil {
+			into = make(map[string]interface{})
+		}
+
+		intoAsObject := into.(map[string]interface{})
+
+		// nextMap represents the subSchema that we want this single item to
+		// conform to
+		properties := from["properties"].(map[string]interface{})
+
+		for property, _nextSchema := range properties {
+
+			nextSchema := _nextSchema.(map[string]interface{})
+
+			// This block becomes active if stuff already exists in "into"
+			// for this property
+			if v, ok := intoAsObject[property]; ok {
+				switch v.(type) {
+
+				case map[string]interface{}:
+					if innerMapAsObj, ok := v.(map[string]interface{}); ok {
+						insertRecursively(innerMapAsObj, nextSchema)
+					}
+
+				case []map[string]interface{}:
+					if innerMapAsArr, ok := v.([]map[string]interface{}); ok {
+						insertRecursively(innerMapAsArr, nextSchema)
+					}
+				}
+				continue
+			}
+
+			// We can't step deeper so we're at an actual key/value
+			// Check to see if we should add a default
+			if d, ok := nextSchema["default"]; ok {
+				intoAsObject[property] = d
+				continue
+			}
+
+			// Finally, if the next schema does exists but there is nothing
+			// in the input object, we want to create a temporary interface, just
+			// in case a nested object has defaults
+			if t, ok := nextSchema["type"]; ok {
+				switch t {
+
+				// If there's an array here, we want to initialize it to an empty
+				// array and leave it at that.
+				case "array":
+					emptyarr := make([]map[string]interface{}, 0)
+					intoAsObject[property] = emptyarr
+
+				case "object":
+					tmpTarget := make(map[string]interface{})
+					insertRecursively(tmpTarget, nextSchema)
+					if len(tmpTarget) > 0 {
+						intoAsObject[property] = tmpTarget
+					}
+				}
+			}
+		}
+	}
+}

--- a/defaults_test.go
+++ b/defaults_test.go
@@ -1,0 +1,150 @@
+package gojsonschema
+
+import (
+	"log"
+	"testing"
+)
+
+func M(in ...interface{}) map[string]interface{} {
+	result := make(map[string]interface{})
+	if len(in)%2 != 0 {
+		log.Fatal("map construction M must have one value for each key")
+	}
+
+	for i := 0; i < len(in); i += 2 {
+		k := in[i]
+		v := in[i+1]
+		sK := k.(string)
+		result[sK] = v
+	}
+
+	return result
+}
+
+// objSchemaFromProperties constructs a schema from "properties"
+func objSchemaFromProperties(properties map[string]interface{}) *Schema {
+	schemaMap := M("type", "object", "properties", properties)
+	loader := NewGoLoader(schemaMap)
+
+	// Since its a test, it'll just fail and then we address later
+	schema, _ := NewSchema(loader)
+
+	return schema
+}
+
+// arrSchemaFromProperties makes sure that each item in an array contains
+// the properties passed in "properties"
+func arrSchemaFromProperties(properties map[string]interface{}) *Schema {
+	objMap := M("type", "object", "properties", properties)
+	arrMap := M("type", "array", "items", objMap)
+
+	loader := NewGoLoader(arrMap)
+
+	// Since its a test, it'll just fail and then we address later
+	schema, _ := NewSchema(loader)
+
+	return schema
+}
+
+// InsertDefaults fails when nil is passed as arguments
+func TestInsertNil(t *testing.T) {
+	properties := M()
+	schema := objSchemaFromProperties(properties)
+
+	_, err := schema.InsertDefaults(nil)
+	if err == nil {
+		t.Error("InsertDefault should fail with a nil argument")
+	}
+}
+
+// InsertDefaults succeeds when empty map is passed as argument
+func TestSimpleDefault(t *testing.T) {
+	properties := M("testkey", M("default", "defaultvalue"))
+	schema := objSchemaFromProperties(properties)
+
+	into := make(map[string]interface{})
+
+	r, err := schema.InsertDefaults(into)
+	if err != nil {
+		t.Error(err)
+	}
+
+	result := r.(map[string]interface{})
+
+	if v := result["testkey"]; v != "defaultvalue" {
+		t.Error("InsertDefaults failed to add 'defaultvalue' at 'testkey'")
+	}
+}
+
+func TestDoesNotOverwrite(t *testing.T) {
+	properties := M("testkey", M("default", "defaultvalue"))
+	schema := objSchemaFromProperties(properties)
+
+	into := make(map[string]interface{})
+	into["testkey"] = "someothervalue"
+
+	r, err := schema.InsertDefaults(into)
+	if err != nil {
+		t.Error(err)
+	}
+
+	result := r.(map[string]interface{})
+
+	if v := result["testkey"]; v != "someothervalue" {
+		t.Error("InsertDefaults has overwritten a value that was there before")
+	}
+}
+
+// TestNestedValues makes sure that a default value several layers deep will be inserted
+func TestNestedValues(t *testing.T) {
+	properties := M("deep", M("type", "object", "properties", M("testkey", M("default", "defaultvalue"))))
+	schema := objSchemaFromProperties(properties)
+
+	into := make(map[string]interface{})
+
+	r, err := schema.InsertDefaults(into)
+	if err != nil {
+		t.Error(err)
+	}
+
+	result := r.(map[string]interface{})
+
+	innerMap := result["deep"].(map[string]interface{})
+
+	if v := innerMap["testkey"]; v != "defaultvalue" {
+		t.Error("InsertDefaults failed to add 'defaultvalue' at .'deep'.'testkey'")
+	}
+}
+
+// If an empty array is passed, nothing should be inserted, even if there
+// is a default value specified somewhere
+func TestSimpleArr(t *testing.T) {
+	properties := M("testkey", M("default", "defaultvalue"))
+	schema := arrSchemaFromProperties(properties)
+
+	examplearr := make([]map[string]interface{}, 0)
+
+	_, err := schema.InsertDefaults(examplearr)
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func TestArrayOfProperties(t *testing.T) {
+	properties := M("testkey", M("default", "defaultvalue"))
+	schema := arrSchemaFromProperties(properties)
+
+	emptyexample := M()
+
+	examplearr := make([]map[string]interface{}, 1)
+	examplearr[0] = emptyexample
+
+	r, err := schema.InsertDefaults(examplearr)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if res := r.([]map[string]interface{}); res[0]["testkey"] != "defaultvalue" {
+		t.Error("array[0] was not filled with the proper default values")
+	}
+}


### PR DESCRIPTION
Added support for default values
Added tests for the following scenarios:

1. Simple base-case testing
2. Array of object with default values
3. Deeply-nested objects
4. Panicking

Note that this is inspired by https://godoc.org/github.com/juju/gojsonschema, which appears to be a fork of this repository. The differences between that and this are:

1. That one will accept nil as an argument, this will not
2. That one does not support array types